### PR TITLE
Add pypi publishing workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,35 @@
+# https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+# https://github.com/marketplace/actions/pypi-publish
+name: upload to pypi
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.5'
+    - name: install deps
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+    - name: build
+      run: |
+        python setup.py sdist bdist_wheel
+    # Try to publish to testpypi first. This will for example fail if we
+    # forgot to bump version number
+    - name: publish to test pypi
+      uses: pypa/gh-action-pypi-publish@v1.2.2
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+    # If the push to testpypi worked, publish to real pypi
+    - name: publish to pypi
+      uses: pypa/gh-action-pypi-publish@v1.2.2
+      with:
+        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
When a new release is created, this first publishes to testpypi
(for sanity checking) and then to the real pypi