### PR TITLE
Add sphinx documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,12 @@
 .vscode
 .venv
 *.egg-info
+docs/_build
 .eggs
 .ipynb_checkpoints
 .pytest_cache
 __pycache__
-build
+venv
+.vscode
 dist
 examples/result.geojson

--- a/README.md
+++ b/README.md
@@ -8,10 +8,25 @@
 
 ![Tests](https://github.com/Picterra/picterra-python/workflows/lint%20and%20tests/badge.svg?branch=master)
 
+Easily integrate state-of-the-art machine learning models in your app
 
-**This is currently experimental and subject to breaking changes**
+```python
+from picterra import APIClient
 
-See the `examples` folder for examples
+# Replace this with the id of one of your detectors
+detector_id = 'd552605b-6972-4a68-8d51-91e6cb531c24'
+
+# Set the PICTERRA_API_KEY environment variable to define your API key
+client = APIClient()
+print('Uploading raster...')
+raster_id = client.upload_raster('data/raster1.tif', name='a nice raster')
+print('Upload finished, starting detector...')
+result_id = client.run_detector(detector_id, raster_id)
+client.download_result_to_file(result_id, 'result.geojson')
+print('Detection finished, results are in result.geojson')
+```
+
+
 
 ## Installation
 
@@ -19,51 +34,13 @@ See the `examples` folder for examples
 pip install git+https://github.com/Picterra/picterra-python.git
 ```
 
-## Example usage
+See the `examples` folder for examples.
 
-### Set API key through an environment variable
+## API Reference and User Guide available on [Read the Docs](https://picterra-python.readthedocs.io/)
 
-```
-export PICTERRA_API_KEY=<your api key>
-```
-
-### Setting detection areas and detecting on a raster
-
-```python
-from picterra import APIClient
-
-raster = '4a45ca8a-1490-46a5-8d78-482ac7abc278'
-detector = '7188815e-a1bc-4e8e-8cb7-54877e640aa0'
-
-pic = APIClient()
-pic.set_raster_detection_areas_from_file(raster, 'detection_areas.geojson')
-result_id = pic.run_detector(detector, raster)
-pic.download_result_to_file(result_id, 'result.geojson')
-```
-
-### Training API (beta)
-
-**Please note the above endpoints are still in beta and thus may be subject to change**
-
-#### Create a detector and add rasters to it
-
-```python
-from picterra import APIClient
-
-pic = APIClient()
-detector = pic.create_detector('my_car_counting_detector', 'count')
-raster1 = pic.upload_raster('<filename1>', 'training_raster_1')
-raster2 = pic.upload_raster('<filename2>', 'training_raster_2')
-pic.add_raster_to_detector(raster1, detector)
-pic.add_raster_to_detector(raster2, detector)
-
-
-```
-
-### Getting results back in pixel coordinates
-
-[Example notebook](examples/nongeo_imagery.ipynb)
+[![Read the Docs](https://storage.googleapis.com/cloud.picterra.ch/external/assets/python_api_docs_screenshot.png)](https://picterra-python.readthedocs.io/)
 
 
 ## Development
+
 In order to test locally, run `python setup.py test`

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,23 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+autobuild:
+	sphinx-autobuild . _build/html --port 9999

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,9 @@
+===
+API
+===
+
+APIClient
+---------
+
+.. autoclass:: picterra.client.APIClient
+    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,66 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+# -- Project information -----------------------------------------------------
+
+project = 'Picterra Python API'
+copyright = '2020, Picterra Team'
+author = 'Picterra Team'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+  'sphinx.ext.autodoc',
+  'sphinx.ext.viewcode',
+  'sphinx.ext.napoleon',
+  'sphinx_rtd_theme',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+html_theme_options = {
+    "show_powered_by": False,
+    "github_user": "Picterra",
+    "github_repo": "picterra-python",
+    "github_banner": True,
+    "show_related": False,
+}
+
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+master_doc = 'index'

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,0 +1,38 @@
+===============
+Getting started
+===============
+
+Installation
+============
+
+Install using pip
+
+::
+
+    pip install git+https://github.com/Picterra/picterra-python.git
+
+Set your Picterra API key through an environment variable
+
+::
+
+    export PICTERRA_API_KEY=<your api key>
+
+
+Upload & Detect
+===============
+
+.. literalinclude:: ../examples/upload_and_detect.py
+
+Training
+========
+
+.. note::
+
+  **Please note the below endpoints are still in beta and thus may be subject to change**
+
+.. literalinclude:: ../examples/upload_and_detect.py
+
+More examples
+=============
+
+Check the `examples directory <https://github.com/Picterra/picterra-python/tree/master/examples>`_ of our github repo.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,22 @@
+Picterra Python API
+===================
+
+Easily integrate state-of-the-art machine learning models in your app
+
+.. raw:: html
+
+    <img src="http://cloud.picterra.ch/external/assets/picterra_api_macbook.png" />
+
+Learn more about `Picterra <http://picterra.ch/for-developers/>`_
+
+If you are looking for our REST API documentation, `look here <https://app.picterra.ch/public/apidocs/v1/>`_
+
+----
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   getting_started
+   api
+

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx-rtd-theme
+sphinx-autobuild

--- a/src/picterra/client.py
+++ b/src/picterra/client.py
@@ -15,6 +15,7 @@ class APIError(Exception):
 
 
 class APIClient():
+    """Main client class for the Picterra API"""
     def __init__(self, api_key=None, base_url=None):
         """
         Args:
@@ -93,11 +94,13 @@ class APIClient():
 
     def list_rasters(self):
         """
-        Returns the list of rasters stored in the account
+        Returns:
+            A list of rasters dictionaries
 
-        Returns: A list of rasters dictionaries
+        Example:
 
-            ```
+            ::
+
                 {
                     'id': '42',
                     'status': 'ready',
@@ -108,7 +111,7 @@ class APIClient():
                     'status': 'ready',
                     'name': 'raster2'
                 }
-            ```
+
         """
         resp = self.sess.get(self._api_url('rasters/'))
         return resp.json()


### PR DESCRIPTION
Here is what it looks like on readthedocs:

https://picterra-python.readthedocs.io/en/latest/index.html

I feel like this could replace the readme and the advantage is that it autodocuments the various functions of the API:

https://picterra-python.readthedocs.io/en/latest/api.html

So then from the public API doc of the REST API, we can just link to readthedocs