### PR TITLE
Add backoff and timeout for requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,6 @@ setup(
         'pytest',
         'flake8',
         'responses',
+        'httpretty'
     ],
 )


### PR DESCRIPTION
Addressing SBB problem with their `list_rasters()` ' 429s.

Closes #32. Refs #25.