### PR TITLE
Fix default init parameters

### DIFF
--- a/src/picterra/client.py
+++ b/src/picterra/client.py
@@ -334,8 +334,6 @@ class APIClient():
         Raises:
             APIError: There was an error while creating the detector
         """
-        detection_type, output_type, training_steps = (
-            detection_type.lower(), output_type.lower(), int(training_steps))
         # Validate args
         validate_detector_args(detection_type, output_type, training_steps)
         # Build request body
@@ -386,7 +384,8 @@ class APIClient():
 
     def edit_detector(
         self, detector_id: str,
-        name: str = '', detection_type: str = '', output_type: str = '', training_steps: int = 0
+        name: str = None, detection_type: str = None, output_type: str = None,
+        training_steps: int = None
     ):
         """
         Edit a detector
@@ -403,8 +402,6 @@ class APIClient():
         Raises:
             APIError: There was an error while editing the detector
         """
-        detection_type, output_type, training_steps = (
-            detection_type.lower(), output_type.lower(), int(training_steps))
         # Validate args
         validate_detector_args(detection_type, output_type, training_steps)
         # Build request body

--- a/src/picterra/client.py
+++ b/src/picterra/client.py
@@ -55,7 +55,7 @@ def validate_detector_args(detection_type: str, output_type: str, training_steps
 class APIClient():
     """Main client class for the Picterra API"""
     def __init__(
-        self, api_key: str = '', base_url: str = '',
+        self, api_key: str = None, base_url: str = None,
         timeout: int = 30, max_retries: int = 3, backoff_factor: int = 10
     ):
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,9 +17,9 @@ TEST_POLL_INTERVAL = 0.1
 OPERATION_ID = 21
 
 
-def _client(max_retries=0, timeout=1):
+def _client(max_retries=0, timeout=1, **kwargs):
     return APIClient(
-        api_key='1234', base_url=TEST_API_URL, max_retries=max_retries, timeout=timeout
+        api_key='1234', base_url=TEST_API_URL, max_retries=max_retries, timeout=timeout, **kwargs
     )
 
 
@@ -482,7 +482,7 @@ def test_backoff_success():
             httpretty.Response(body=json.dumps(data),status=200)
         ]
     )
-    client = _client(max_retries=2)
+    client = _client(max_retries=2, backoff_factor=0.1)
     client.list_rasters()
     assert len(httpretty.latest_requests()) == 3
 


### PR DESCRIPTION
This fixes an issue where you couldn't override the base url through environment variables anymore (because of using empty string as default paramters).

Also unifies to using `None` to indicate unset parameters instead of empty strings / 0