### PR TITLE
Add multiclass support when running detectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ print('Uploading raster...')
 raster_id = client.upload_raster('data/raster1.tif', name='a nice raster')
 print('Upload finished, starting detector...')
 result_id = client.run_detector(detector_id, raster_id)
-client.download_result_to_file(result_id, 'result.geojson')
+client.download_result_to_feature_collection(result_id, 'result.geojson')
 print('Detection finished, results are in result.geojson')
 ```
 

--- a/examples/upload_and_detect.py
+++ b/examples/upload_and_detect.py
@@ -17,5 +17,5 @@ raster_id = client.upload_raster(
 )
 print('Upload finished, starting detector...')
 result_id = client.run_detector(detector_id, raster_id)
-client.download_result_to_file(result_id, 'result.geojson')
+client.download_result_to_feature_collection(result_id, 'result.geojson')
 print('Detection finished, results are in result.geojson')

--- a/src/picterra/__main__.py
+++ b/src/picterra/__main__.py
@@ -185,11 +185,11 @@ def parse_args(args):
         if options.output_type == 'geometries':   # outputting/saving result geometries
             if options.output_file:
                 logger.debug('Detection finished, writing result to %s' % options.output_file)
-                client.download_result_to_file(operation_id, options.output_file)
+                client.download_result_to_feature_collection(operation_id, options.output_file)
             else:
                 from tempfile import mkstemp
                 fd, path = mkstemp()
-                client.download_result_to_file(operation_id, path)
+                client.download_result_to_feature_collection(operation_id, path)
                 logger.debug('Detection finished, outputting result data')
                 with open(path) as f:
                     for piece in _read_in_chunks(f):

--- a/src/picterra/client.py
+++ b/src/picterra/client.py
@@ -516,6 +516,20 @@ class APIClient():
         with open(filename, 'w') as f:
             f.write(data)
 
+    def get_operation_results(self, operation_id: str) -> str:
+        """
+        Return the 'results' dict of an operation
+
+        This a **beta** function, subject to change.
+
+        Args:
+            operation_id (str): The id of the operation
+        """
+        resp = self.sess.get(
+            self._api_url('operations/%s/' % operation_id),
+        )
+        return resp.json()['results']
+
     def get_operation_results_url(self, operation_id: str) -> str:
         """
         Get the URL  of a set of results
@@ -525,11 +539,7 @@ class APIClient():
         Args:
             result_id (str): The id of the result
         """
-        resp = self.sess.get(
-            self._api_url('operations/%s/' % operation_id),
-        )
-        # This might raise KeyError for some operations
-        return resp.json()['results']['url']
+        return self.get_operation_results(operation_id)['url']
 
     def set_annotations(self, detector_id, raster_id, annotation_type, annotations):
         """

--- a/tests/test_module_cli.py
+++ b/tests/test_module_cli.py
@@ -71,7 +71,7 @@ def test_prediction(monkeypatch, capsys):
     monkeypatch.setattr(APIClient, '__init__', _fake__init__)
     mock_run, mock_download_file, mock_download_url, mock_url = MagicMock(return_value='foobar'), MagicMock(),  MagicMock(), MagicMock(return_value='spam')
     monkeypatch.setattr(APIClient, 'run_detector', mock_run)
-    monkeypatch.setattr(APIClient, 'download_result_to_file', mock_download_file)
+    monkeypatch.setattr(APIClient, 'download_result_to_feature_collection', mock_download_file)
     monkeypatch.setattr(APIClient, 'download_operation_results_to_file', mock_download_url)
     monkeypatch.setattr(APIClient, 'get_operation_results_url', mock_url)
     monkeypatch.setattr(__main__, '_read_in_chunks', _mock_read_in_chunks)


### PR DESCRIPTION
This adds multiclass support by saving a `FeatureCollection` of `MultiPolygon` with a `class_name` property.

This would break `download_result_to_file` though because it was saving directly the `MultiPolygon` to the `.geojson` file. So we could introduce this under a new function and [deprecate](https://docs.python.org/3/library/warnings.html) `download_result_to_file`.

- [x] Decide if this should be introduced in new function
- [x] Tests
- [x] Fix commit message