### PR TITLE
[endpoint] Added new method to access the raster details

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ See the `examples` folder for examples.
 [![Read the Docs](https://storage.googleapis.com/cloud.picterra.ch/external/assets/python_api_docs_screenshot.png)](https://picterra-python.readthedocs.io/)
 
 
+## Test locally
+
+run:
+```
+python setup.py install
+```
+
+Then you need to set the following environment variables:
+```bash
+export PICTERRA_API_KEY='' # Generate from local platform account Ex:1234
+export PICTERRA_BASE_URL='' # Ex: http://localhost:8080/public/api/v2/
+```
+
+
 ## Development
 
-In order to test locally, run `python setup.py test`
+In order to test locally, run:
+```bash
+python setup.py test
+```

--- a/src/picterra/client.py
+++ b/src/picterra/client.py
@@ -305,6 +305,26 @@ class APIClient():
         """
         params = {'folder': folder_id} if folder_id else {}
         return self._paginate_through_list('rasters', params)
+    
+    def get_raster(
+        self, raster_id: str
+    ):
+        """
+        Get raster information
+
+        Args:
+            raster_id (str): id of the raster
+
+        Raises:
+            APIError: There was an error while getting the raster information
+
+        Returns:
+            dict: Dictionary of the information
+        """
+        resp = self.sess.get(self._api_url('rasters/%s/' % raster_id))
+        if not resp.ok:
+            raise APIError(resp.text)
+        return resp.json()
 
     def edit_raster(
         self, raster_id: str,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -452,6 +452,19 @@ def test_edit_raster(edited_data):
 
 
 @responses.activate
+def test_get_raster():
+    """Test the raster information"""
+    RASTER_ID = 'foobar'
+    client = _client()
+    responses.add(
+        responses.GET,
+        api_url('rasters/%s/' % RASTER_ID), status=201,
+        json={})
+    resp = client.get_raster(RASTER_ID)
+    assert len(responses.calls) == 1
+
+
+@responses.activate
 def test_delete_raster():
     RASTER_ID = 'foobar'
     client = _client()
@@ -494,7 +507,6 @@ def test_list_rasters():
     rasters = client.list_rasters('foobar')
     assert rasters[0]['name'] == 'raster_in_folder1'
     assert rasters[0]['folder_id'] == 'foobar'
-
 
 
 @responses.activate


### PR DESCRIPTION
### New method
A new method was added to get raster info from the API call https://app.picterra.ch/public/apidocs/v2/#tag/rasters/operation/getRasterById.

I also added an e2e test to ensure it works in a local environment.

fix #73 