### PR TITLE
Drop support for python 3.5, remove requests pinning

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.7]
+        python-version: ['3.7', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,12 @@ setup(
         'flake8',
     ],
     install_requires=[
-        'requests<=2.26.0',
+        'requests',
     ],
     tests_require=[
-        'pytest===6.1.2',
+        'pytest==7.1',
         'flake8',
-        'responses==0.17.0',
+        'responses==0.22',
         'httpretty'
     ],
 )


### PR DESCRIPTION
According to https://devguide.python.org/versions/, 3.7 is the oldest version that's still supported.

Closes #72