### PR TITLE
Remove raster upload support from python lib

### DIFF
--- a/examples/raster_management.py
+++ b/examples/raster_management.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pprint import pprint
+
 from picterra import APIClient
 
 # Set the PICTERRA_API_KEY environment variable to define your API key
@@ -14,22 +15,6 @@ print('Uploaded local raster=', local_raster_id)
 
 for raster in client.list_rasters():
     pprint('raster %s' % "\n".join(["%s=%s" % item for item in raster.items()]))
-
-wms_raster_id = client.upload_remote_raster(
-    'wms', 'http://wms.zh.ch/OrthoZHWMS?LAYERS=OrthoZHWMS', 0.3,
-    footprint={
-        "type": "Polygon",
-        "coordinates": [[
-            [8.531441688537598, 47.3669375756445],
-            [8.555259704589844, 47.3669375756445],
-            [8.555259704589844, 47.37530808909385],
-            [8.531441688537598, 47.37530808909385],
-            [8.531441688537598, 47.3669375756445]
-        ]]
-    },
-    name='A WMS raster in a folder', folder_id=folder_id, captured_at="2019-01-01T12:34:56.789Z"
-)
-print('Uploaded WMS raster=', wms_raster_id)
 
 for raster in client.list_rasters(folder_id):
     pprint('raster %s' % "\n".join(["%s=%s" % item for item in raster.items()]))

--- a/src/picterra/client.py
+++ b/src/picterra/client.py
@@ -1,14 +1,15 @@
-import os
-import time
 import json
-import requests
-import tempfile
 import logging
+import os
+import tempfile
+import time
 import warnings
-from urllib.parse import urljoin, urlencode
+from typing import List, Optional
+from urllib.parse import urlencode, urljoin
+
+import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
-from typing import List, Optional
 
 logger = logging.getLogger()
 
@@ -222,65 +223,6 @@ class APIClient():
             raise APIError(resp.text)
         self._wait_until_operation_completes(resp.json())
         return raster_id
-
-    def upload_remote_raster(
-        self, server_type: str, server_url: str, spatial_resolution_meters: float, footprint: dict,
-        credentials: Optional[str] = None, name: Optional[str] = None,
-        folder_id: Optional[str] = None, captured_at: Optional[str] = None
-    ) -> str:
-        """
-        **closed beta**: This API endpoint is currently in closed beta and unstable.
-
-        Upload a remote raster to picterra (WMS or XYZ imagery server sources).
-
-        Args:
-            server_type (str): One of ['wms', 'xyz']
-            server_url (str): URL for the imagery server
-            spatial_resolution_meters (float): GSD of the image we want to import
-            footprint (dict): GeoJSON Polygon containing the boundaries of the remote raster
-            credentials (optional, str): Credentials for the imagery server in the
-                "user:password" format, if needed
-            name (optional, str): Name the raster will take
-            folder_id (optional, str): Identifier of the folder this raster will belongs to;
-                if not provided, the raster will be put in the "Picterra API Project" folder
-            captured_at (optional, str): ISO-8601 date and time at which this
-                raster was captured, YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z];
-                e.g. "2020-01-01T12:34:56.789Z"
-
-        Returns:
-            raster_id (str): The id of the uploaded raster
-
-        Raises:
-            APIError: There was an error while trying to upload the raster
-            ValueError: One of the parameters is wrong
-
-        """
-        warnings.warn("This function is unstable and currently in closed beta. Use at your own risks")
-
-        valid_types = ['wms', 'xyz']
-        server_type = server_type.lower()
-        if server_type not in valid_types:
-            raise ValueError('Invalid remote raster type "%s"; allowed values are: %s.' % (
-                server_type, ', '.join(valid_types)))
-        post_body = {
-            'type': server_type,
-            'url': server_url,
-            'spatial_res_m': float(spatial_resolution_meters),
-            'footprint': footprint
-        }
-        if folder_id:
-            post_body['folder_id'] = folder_id
-        if captured_at:
-            post_body['captured_at'] = captured_at
-        if credentials:
-            post_body['credentials'] = credentials
-        if name:
-            post_body['name'] = name
-        resp = self.sess.post(self._api_url('rasters/upload/remote/'), json=post_body)
-        if not resp.ok:
-            raise APIError(resp.text)
-        operation = self._wait_until_operation_completes(resp.json())
-        return operation['metadata']['raster_id']
 
     def list_rasters(
         self, folder_id: Optional[str] = None, search_string: Optional[str] = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,14 +1,15 @@
-import tempfile
-import responses
-import httpretty
-import pytest
-import time
 import json
 import os
+import tempfile
+import time
 from urllib.parse import urljoin
-from requests.exceptions import ConnectionError
-from picterra import APIClient
 
+import httpretty
+import pytest
+import responses
+from requests.exceptions import ConnectionError
+
+from picterra import APIClient
 
 TEST_API_URL = 'http://example.com/public/api/v2/'
 
@@ -241,16 +242,6 @@ def add_mock_raster_upload_responses(identity_key, multispectral):
         json=data, status=200)
 
 
-def add_mock_remote_raster_upload_responses(type):
-    data = {
-        'poll_interval': TEST_POLL_INTERVAL,
-        'operation_id': OPERATION_ID
-    }
-    responses.add(
-        responses.POST,
-        api_url('rasters/upload/remote/'), json=data, status=201)
-
-
 def add_mock_detection_areas_upload_responses(raster_id):
     upload_id = 42
 
@@ -452,24 +443,6 @@ def test_upload_raster(identity_key, multispectral):
             multispectral=multispectral
         )
     assert len(responses.calls) == 4
-
-
-@pytest.mark.parametrize('type', ('xyz', 'wms'))
-@responses.activate
-def test_upload_remote_raster(type):
-    client = _client()
-    add_mock_remote_raster_upload_responses(type)
-    add_mock_operations_responses('processing')
-    add_mock_operations_responses('success')
-    footprint = {
-        "type": "Polygon",
-        "coordinates": [ [ [10.0, 0.0], [11.0, 0.0], [11.0, 1.0],  [10.0, 1.0], [10.0, 0.0] ] ]
-    }
-    with pytest.raises(ValueError):
-        client.upload_remote_raster('spam', 'http://example.com', 0.2, footprint)
-    client.upload_remote_raster(type, 'http://example.com', 0.2, footprint)
-    # (1 call for the upload, 2 for the polling)
-    assert len(responses.calls) == 3
 
 
 @pytest.mark.parametrize('edited_data', (


### PR DESCRIPTION
We are deprecating this endpoint and removing it from the public lib. We'll add this back later once the remote import solution stabilizes on the platform and we can design a public endpoint for it.