### PR TITLE
Revert "[urllib] Replace method_whitelist with allowed_methods"

### DIFF
--- a/src/picterra/client.py
+++ b/src/picterra/client.py
@@ -106,7 +106,7 @@ class APIClient():
             total=max_retries,
             status_forcelist=[429, 502, 503, 504],
             backoff_factor=backoff_factor,
-            allowed_methods=["GET"]
+            method_whitelist=["GET"]
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         self.sess.mount("https://", adapter)


### PR DESCRIPTION
This reverts commit 395745537a716bb52c38f88137d9526324a12ad0.

This commit broke the library on some older requests version. It seems we need to be more explicit about requests requirement before landing this change.

Ref #84