### PR TITLE
Create markers which are only associated with rasters 

### DIFF
--- a/src/picterra/client.py
+++ b/src/picterra/client.py
@@ -843,7 +843,7 @@ class APIClient():
         return self._paginate_through_list(url)
 
 
-    def create_marker(self, raster_id: UUID, detector_id: UUID, lng: float, lat: float, text: str):
+    def create_marker(self, raster_id: UUID, detector_id: Optional[UUID], lng: float, lat: float, text: str):
         """
         This is an **experimental** (beta) feature
 
@@ -851,12 +851,16 @@ class APIClient():
 
         Args:
             raster_id: The id of the raster (belonging to detector) to create the marker on
-            detector_id: The id of the detector to create the marker on
+            detector_id: The id of the detector to create the marker on. If this is None, the marker
+                is created associated with the raster only
 
         Raises:
             APIError: There was an error while creating the marker
         """
-        url = 'detectors/%s/training_rasters/%s/markers/' %(detector_id, raster_id)
+        if detector_id is None:
+            url = 'rasters/%s/markers/' % raster_id
+        else:
+            url = 'detectors/%s/training_rasters/%s/markers/' %(detector_id, raster_id)
         data = {
             "marker": {"type": "Point", "coordinates": [lng, lat]},
             "text": text,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -418,7 +418,10 @@ def add_mock_raster_markers_list_response(raster_id):
 
 
 def add_mock_marker_creation_response(marker_id, raster_id, detector_id, coords, text):
-    url = 'detectors/%s/training_rasters/%s/markers/' %(detector_id, raster_id)
+    if detector_id is None:
+        url = 'rasters/%s/markers/' % raster_id
+    else:
+        url = 'detectors/%s/training_rasters/%s/markers/' %(detector_id, raster_id)
     body = {
         "marker": {"type": "Point", "coordinates": coords},
         "text": text,
@@ -706,6 +709,12 @@ def test_list_raster_markers():
     marker = client.create_marker('foo', 'bar', 12.34, 56.78, 'foobar')
     assert marker['id'] == 'spam'
 
+@responses.activate
+def test_create_raster_marker():
+    client = _client()
+    add_mock_marker_creation_response('id123', 'rasterid123', None, [43.21, 87.65], 'comment')
+    marker = client.create_marker('rasterid123', None, 43.21, 87.65, 'comment')
+    assert marker['id'] == 'id123'
 
 # Cannot test Retry with responses, @see https://github.com/getsentry/responses/issues/135
 @httpretty.activate


### PR DESCRIPTION
Adds the ability to the API client to create raster markers (those associated with a raster but not a detector).