### PR TITLE
Change `list_XXX` functions to not automatically paginate through the whole list, bump version to 2

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,6 +9,12 @@ APIClient
 .. autoclass:: picterra.client.APIClient
     :members:
 
+Pagination
+----------
+
+.. autoclass:: picterra.client.ResultsPage
+    :members:
+
 
 nongeo
 ------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -9,13 +9,27 @@ Install using pip
 
 ::
 
-    pip install git+https://github.com/Picterra/picterra-python.git
+    pip install picterra
 
 Set your Picterra API key through an environment variable
 
 ::
 
     export PICTERRA_API_KEY=<your api key>
+
+Listing entities
+================
+
+When listing entities (eg rasters, detectors) from your account, the Picterra Server uses a *paginated*
+approach; this means that every `list_`-prefixed function returns a special `ResultsPage` class instance
+which has the following properties, similarly to a Python list:
+* is iterable over the elements in the page, eg with a `for`
+* can be applied the builtin `len` to get the number of elements in the page
+* returns the `n`-th element of the page simply accessing with `[n]` (0-indexed)
+* has a `next()` method which returns the following `ResultsPage`, if any, otherwise `None`
+
+.. literalinclude:: ../examples/detectors_management.py
+.. literalinclude:: ../examples/raster_management.py
 
 
 Upload & Detect

--- a/examples/detectors_management.py
+++ b/examples/detectors_management.py
@@ -12,14 +12,16 @@ detector_id = client.create_detector("My first detector")
 client.edit_detector(detector_id, "Renamed detector", "segmentation", "bbox", 1000)
 
 # List existing detectors
-for d in client.list_detectors():
-    print(
-        "detector id=%s, name=%s, detection_type=%s, output_type=%s, training_steps=%d"
-        % (
-            d["id"],
-            d["name"],
-            d["configuration"]["detection_type"],
-            d["configuration"]["output_type"],
-            d["configuration"]["training_steps"],
-        )
+detectors_page_1 = client.list_detectors()
+print("Page has " + str(len(detectors_page_1)) + " elements")
+d = detectors_page_1[0]
+print(
+    "detector id=%s, name=%s, detection_type=%s, output_type=%s, training_steps=%d"
+    % (
+        d["id"],
+        d["name"],
+        d["configuration"]["detection_type"],
+        d["configuration"]["output_type"],
+        d["configuration"]["training_steps"],
     )
+)

--- a/examples/raster_management.py
+++ b/examples/raster_management.py
@@ -9,16 +9,19 @@ from picterra import APIClient
 client = APIClient()
 # The Id of a folder/project you own
 folder_id = "7ec40c11-f181-436a-9d33-d7b3f63e0e0f"
-
+# Upload
 local_raster_id = client.upload_raster("data/raster1.tif", name="A nice raster")
 print("Uploaded local raster=", local_raster_id)
-
-for raster in client.list_rasters():
+# Get the first batch of most recent images
+first_page = client.list_rasters()
+for raster in first_page:
     pprint("raster %s" % "\n".join(["%s=%s" % item for item in raster.items()]))
-
+# Get the second batch
+second_page = first_page.next()
+# Get the first page applying a filter
 for raster in client.list_rasters(folder_id):
     pprint("raster %s" % "\n".join(["%s=%s" % item for item in raster.items()]))
-
+# Upload and removal
 local_raster_id = client.upload_raster("data/raster1.tif", name="A short-lived raster")
 print("Uploaded a second local raster=", local_raster_id)
 client.delete_raster(local_raster_id)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ test_deps = ["pytest==7.1", "responses==0.22", "httpretty"]
 
 setup(
     name="picterra",
-    version="1.3.0a0",
+    version="2.0.0",
     description="Picterra API client",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The `list_XXX` functions would paginate through the whole list of entities by default. This is historical and doesn't make much sense anymore (see #111). This is fixing this behavior and returning a `ResultsPage` object to the user who can then decide for themselves if they need the whole list (probably not) or not.

TODOs:
- [ ] Major version bump to 2.X (this breaks existing behavior)