### PR TITLE
Rework dependencies specification by using setup.py extras

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.10']
+        python-version: ['3.10', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,12 +23,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel flake8 twine
         python setup.py develop
+        pip install -e .[test,lint]
     - name: lint
       run: |
         python -m flake8
     - name: tests
       run: |
-        python setup.py test
+        pytest -v tests
     # Test the build and run twine to check we are pypi compatible
     - name: check build
       run: |

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx==7.2.6
 sphinx-rtd-theme
 sphinx-autobuild

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ from pathlib import Path
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
+lint_deps = ["flake8"]
+test_deps = ["pytest==7.1", "responses==0.22", "httpretty"]
+
 setup(
     name="picterra",
     version="1.2.2",
@@ -15,14 +18,13 @@ setup(
     long_description_content_type="text/markdown",
     package_dir={"": "src"},
     packages=find_packages("src"),
-    setup_requires=[
-        "pytest-runner",
-        "flake8",
-    ],
     install_requires=[
         "requests",
         # We use the new `allowed_methods` option
         "urllib3>=1.26.0",
     ],
-    tests_require=["pytest==7.1", "flake8", "responses==0.22", "httpretty"],
+    extras_require={
+        'test': test_deps,
+        'lint': lint_deps,
+    }
 )


### PR DESCRIPTION
test_requires and `python setup.py test` are [deprecated](https://github.com/pypa/setuptools/issues/1684). The new way is to specify extra dependencies for the package through `extra_requires`.