### PR TITLE
Make the library compatible with older python versions

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.12']
+        python-version: ['3.7', '3.10', '3.12']
 
     steps:
     - uses: actions/checkout@v2
@@ -38,6 +38,8 @@ jobs:
     # therefore fail on warnings that could be ignored by readthedocs and
     # lead to half-broken docs
     - name: build docs
+      # This should make the version in .readthedocs.yaml in the repository root
+      if: matrix.python-version == '3.12'
       run: |
         cd docs
         python -m pip install -r requirements.txt

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # We still support python 3.7 for entreprise customers running on legacy
+        # Python versions
         python-version: ['3.7', '3.10', '3.12']
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # read the contents of your README file
+import sys
 from pathlib import Path
-
 from setuptools import find_packages, setup
 
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
-lint_deps = ["flake8", "mypy==1.8.0", "types-requests"]
+if sys.version_info >= (3, 8):
+    lint_deps = ["flake8", "mypy==1.8.0", "types-requests"]
+else:
+    lint_deps = ["flake8", "mypy==1.4.1", "types-requests"]
 test_deps = ["pytest==7.1", "responses==0.22", "httpretty"]
 
 setup(

--- a/src/picterra/base_client.py
+++ b/src/picterra/base_client.py
@@ -1,9 +1,16 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
+import sys
 import time
 from collections.abc import Callable
-from typing import Any, Generic, Iterator, Literal, TypedDict, TypeVar
+if sys.version_info >= (3, 8):
+    from typing import Literal, TypedDict
+else:
+    from typing_extensions import Literal, TypedDict
+from typing import Any, Generic, Iterator, TypeVar
 from urllib.parse import urlencode, urljoin
 
 import requests

--- a/src/picterra/detector_platform_client.py
+++ b/src/picterra/detector_platform_client.py
@@ -5,11 +5,18 @@ https://app.picterra.ch/public/apidocs/v2/
 Note that that Detector platform is a separate product from the Plots Analysis platform and so
 an API key which is valid for one may encounter permissions issues if used with the other
 """
+from __future__ import annotations
+
 import json
 import logging
+import sys
 import tempfile
 import warnings
-from typing import Any, Literal
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+from typing import Any
 
 import requests
 

--- a/src/picterra/plots_analysis_platform_client.py
+++ b/src/picterra/plots_analysis_platform_client.py
@@ -6,7 +6,12 @@ Note that that Plots Analysis Platform is a separate product from the Detector p
 an API key which is valid for one may encounter permissions issues if used with the other
 """
 import datetime
-from typing import Literal
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 import requests
 from requests.exceptions import RequestException


### PR DESCRIPTION
A combination of importing `from __future__ import annotations` and doing some conditional imports based on `sys.version_info` allows us to keep using a more modern annotations style but keep the library compatible with versions back to at least 3.7 (that's as far as I tested).

I've also added a build & lint step for version 3.7 and adjusted the build configuration so that we only test making the docs on python version 3.12 ( which is what we have configured in the `.readthedocs.yaml` config file