### PR TITLE
Fix `download_vector_layer_to_file` mocking and output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 # read the contents of your README file
 import sys
 from pathlib import Path
+
 from setuptools import find_packages, setup
 
 this_directory = Path(__file__).parent
@@ -16,7 +17,7 @@ test_deps = ["pytest==7.1", "responses==0.22", "httpretty"]
 
 setup(
     name="picterra",
-    version="2.0.1",
+    version="2.0.2",
     description="Picterra API client",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/picterra/base_client.py
+++ b/src/picterra/base_client.py
@@ -6,10 +6,12 @@ import os
 import sys
 import time
 from collections.abc import Callable
+
 if sys.version_info >= (3, 8):
     from typing import Literal, TypedDict
 else:
     from typing_extensions import Literal, TypedDict
+
 from typing import Any, Generic, Iterator, TypeVar
 from urllib.parse import urlencode, urljoin
 
@@ -73,6 +75,19 @@ def _upload_file_to_blobstore(upload_url: str, filename: str):
         logger.error("Error when uploading to blobstore %s" % upload_url)
         raise APIError(resp.text)
 
+
+def multipolygon_to_feature_collection(mp):
+    return {
+        "type": "FeatureCollection",
+        "features": [{
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": p
+            }
+        } for p in mp]
+    }
 
 T = TypeVar("T")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -392,23 +392,14 @@ def add_mock_vector_layer_download_responses(layer_id, num_features):
         "download_url": "http://layer.geojson.example.com",
     }
     add_mock_operations_responses("success", results=results)
-    features = []
-    for i in range(num_features):
-        url = results["download_url"]
-        features.append(
-            {
-                "type": "Feature",
-                "geometry": make_geojson_multipolygon(i + 1),
-                "properties": {},
-            }
-        )
-    fc = {"type": "FeatureCollection", "features": features}
+    url = results["download_url"]
+    mp = make_geojson_multipolygon(2)
     responses.add(
         responses.GET,
         url,
-        body=json.dumps(fc),
+        body=json.dumps(mp),
     )
-    return fc
+    return mp
 
 
 def make_geojson_multipolygon(npolygons=1):
@@ -1008,11 +999,11 @@ def test_download_vector_layer_to_file(monkeypatch):
     client = _client(monkeypatch)
     with tempfile.NamedTemporaryFile() as fp:
         client.download_vector_layer_to_file("foobar", fp.name)
-        fc = json.load(fp)
-        assert fc == expected_content and len(fc["features"]) == 2
+        mp = json.load(fp)
         assert (
-            fc["type"] == "FeatureCollection" and fc["features"][0]["type"] == "Feature"
+            mp["type"] == "MultiPolygon"
         )
+        assert mp == expected_content and len(mp["coordinates"]) == 2
     assert len(responses.calls) == 3 # POST /download, GET /operations, GET url
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,6 +7,7 @@ import pytest
 import responses
 from requests.exceptions import ConnectionError
 
+from picterra.base_client import multipolygon_to_feature_collection
 from picterra.detector_platform_client import DetectorPlatformClient
 from tests.utils import (
     OP_RESP,
@@ -399,7 +400,7 @@ def add_mock_vector_layer_download_responses(layer_id, num_features):
         url,
         body=json.dumps(mp),
     )
-    return mp
+    return multipolygon_to_feature_collection(mp)
 
 
 def make_geojson_multipolygon(npolygons=1):
@@ -999,11 +1000,11 @@ def test_download_vector_layer_to_file(monkeypatch):
     client = _client(monkeypatch)
     with tempfile.NamedTemporaryFile() as fp:
         client.download_vector_layer_to_file("foobar", fp.name)
-        mp = json.load(fp)
+        fc = json.load(fp)
         assert (
-            mp["type"] == "MultiPolygon"
+            fc["type"] == "FeatureCollection"
         )
-        assert mp == expected_content and len(mp["coordinates"]) == 2
+        assert fc == expected_content and len(fc["features"]) == 2
     assert len(responses.calls) == 3 # POST /download, GET /operations, GET url
 
 


### PR DESCRIPTION
This:

- Fixes the `add_mock_vector_layer_download_responses` mock which was incorrectly returning a `FeatureCollection` when our public API actually returns results as a `MultiPolygon`.
- Updates `download_vector_layer_to_file` to convert that `MultiPolygon` into a `FeatureCollection`
- Bumps the package version to 2.0.2