### PR TITLE
Fix docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,36 +3,31 @@ API
 ===
 
 
-DetectorPlatformClient
-----------------------
+Detector Platform
+-----------------
+
+.. autoclass:: picterra.DetectorPlatformClient
+    :members:
 
 .. autoclass:: picterra.APIClient
     :members:
-
-
-PlotsAnalysisPlatformClient
----------------------------
-
-.. autoclass:: picterra.PlotsAnalysisPlatformClient
-    :members:
-
-
-Pagination
-----------
-
-.. autoclass:: picterra.ResultsPage
-    :members:
-
-
-nongeo
-------
 
 .. automodule:: picterra.nongeo
     :members:
 
 
-Exceptions
-----------
+Plots Analysis Platform
+-----------------------
+
+.. autoclass:: picterra.PlotsAnalysisPlatformClient
+    :members:
+
+
+Utility classes
+---------------
+
+.. autoclass:: picterra.ResultsPage
+    :members:
 
 .. autoclass:: picterra.APIError
     :members:


### PR DESCRIPTION
In https://github.com/Picterra/picterra-python/pull/131, we turned APIClient into an alias for DetectorPlatformClient,
but that broke the docs since calling :members: on APIClient wouldn't
display any functions

So this adds both APIClient and DetectorPlatformClient to the API docs

## What we currently have on readthedocs

![image](https://github.com/user-attachments/assets/21101837-3fe4-49e5-833f-73b0d29864a8)

## What this looks like (local docs build)

![image](https://github.com/user-attachments/assets/0e7b1468-ad1f-403f-a9b7-086e4b3ba39e)

