### PR TITLE
Remove time component from assessment dates

### DIFF
--- a/examples/plots_analysis.py
+++ b/examples/plots_analysis.py
@@ -16,7 +16,7 @@ print("Starting analysis...")
 results = client.batch_analyze_plots(
     plots_feature_collection_filename,
     "eudr_cocoa",
-    datetime.datetime.fromisoformat("2022-01-01")
+    datetime.date.fromisoformat("2022-01-01")
 )
 
 # The output of the analysis is a JSON file containing the input plots and their

--- a/src/picterra/plots_analysis_platform_client.py
+++ b/src/picterra/plots_analysis_platform_client.py
@@ -25,7 +25,7 @@ class PlotsAnalysisPlatformClient(BaseAPIClient):
     def __init__(self, **kwargs):
         super().__init__("public/api/plots_analysis/v1/", **kwargs)
 
-    def batch_analyze_plots(self, plots_geometries_filename: str, methodology: AnalysisMethodology, assessment_date: datetime.datetime):
+    def batch_analyze_plots(self, plots_geometries_filename: str, methodology: AnalysisMethodology, assessment_date: datetime.date):
         """
         Runs the specified methodology against the plot geometries stored in the provided file and
         returns the analysis results.

--- a/tests/test_plots_analysis_client.py
+++ b/tests/test_plots_analysis_client.py
@@ -59,6 +59,6 @@ def test_analyse_plots(monkeypatch):
         results = client.batch_analyze_plots(
             tmp.name,
             methodology="eudr_cocoa",
-            assessment_date=datetime.datetime.fromisoformat("2020-01-01"),
+            assessment_date=datetime.date.fromisoformat("2020-01-01"),
         )
     assert results == fake_analysis_results


### PR DESCRIPTION
Picterra's backend expects a YYYY-MM-DD date with no time component.