### PR TITLE
Release 2.0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ test_deps = ["pytest==7.1", "responses==0.22", "httpretty"]
 
 setup(
     name="picterra",
-    version="2.0.3",
+    version="2.0.4",
     description="Picterra API client",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Mostly to get the fix for `datetime.datetime` to `datetime.date` in.

Note that this is backward compatible: i.e. if someone installs the python SDK today (before we update the API endpoint) and calls the public API with just a date instead of datetime, that should work.