### PR TITLE
Rename id property to plot_id in example data

### DIFF
--- a/examples/data/plots_analysis/example_plots.geojson
+++ b/examples/data/plots_analysis/example_plots.geojson
@@ -3,7 +3,7 @@
   "features": [
     {
       "type": "Feature",
-      "properties": { "id": "PLOT-1"},
+      "properties": { "plot_id": "PLOT-1"},
       "geometry": {
         "coordinates": [
           [
@@ -34,7 +34,7 @@
     },
     {
       "type": "Feature",
-      "properties": { "id": "PLOT-2"},
+      "properties": { "plot_id": "PLOT-2"},
       "geometry": {
         "coordinates": [
           [


### PR DESCRIPTION
This fixes a minor issue in our example data that used an incorrectly named property, resulting in an error when running the example.