### PR TITLE
Improve error messages for PlotsAnalysisPlatformClient

### DIFF
--- a/src/picterra/detector_platform_client.py
+++ b/src/picterra/detector_platform_client.py
@@ -29,7 +29,6 @@ from picterra.base_client import (
     FeatureCollection,
     _download_to_file,
     _upload_file_to_blobstore,
-    multipolygon_to_polygon_feature_collection,
 )
 
 logger = logging.getLogger()


### PR DESCRIPTION
`raise_for_status` doesn't give a very helpful message, so this commit instead returns the inner exception which has more details.

This also follows more closely the error handling pattern used in the `DetectorPlatformClient`.