### PR TITLE
[docs] Improve listing entities documentation

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -21,12 +21,11 @@ Listing entities
 ================
 
 When listing entities (eg rasters, detectors) from your account, the Picterra Server uses a *paginated*
-approach; this means that every `list_`-prefixed function returns a special `ResultsPage` class instance
-which has the following properties, similarly to a Python list:
-* is iterable over the elements in the page, eg with a `for`
-* can be applied the builtin `len` to get the number of elements in the page
-* returns the `n`-th element of the page simply accessing with `[n]` (0-indexed)
-* has a `next()` method which returns the following `ResultsPage`, if any, otherwise `None`
+approach; this means that every `list_`-prefixed function returns a special :class:`picterra.ResultsPage` class instance
+which can be used like a Python list.
+
+Here are some examples, but look at the doc for :class:`picterra.DetectorPlatformClient` and :class:`picterra.PlotsAnalysisPlatformClient`
+for all the entities you can list.
 
 .. literalinclude:: ../examples/detectors_management.py
 .. literalinclude:: ../examples/raster_management.py

--- a/src/picterra/base_client.py
+++ b/src/picterra/base_client.py
@@ -129,10 +129,12 @@ class ResultsPage(Generic[T]):
     in pages (page 1, page 2, etc..) of a fixed dimension (eg 20). Thus
     each `list_XX` function returns a ResultsPage (by default the first one);
     once you have a ResultsPage for a given list of objects, you can:
+
     * check its length with `len()` (eg `len(page)`)
     * access a single element with the index operator `[]` (eg `page[5]`)
     * turn it into a list of dictionaries with  `list()` (eg `list(page)`)
     * get the next page with `.next()` (eg `page.next()`); this could return
+
     None if the list is finished
     You can also get a specific page passing the page number to the `list_XX` function
     """


### PR DESCRIPTION
- Add link to ResultsPage instead of duplicating the docstring
- Point out that one should look at the client for all entities that can be listed