### PR TITLE
Upgrade python version used in test publish workflow

### DIFF
--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -15,7 +15,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.12'
     - name: install deps
       run: |
         python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
It appears that 3.7 is no longer available as the python version in setup-python action