### PR TITLE
Change order of arguments in Tracer client to simplify future url flattening

### DIFF
--- a/src/picterra/tracer_client.py
+++ b/src/picterra/tracer_client.py
@@ -295,15 +295,15 @@ class TracerClient(BaseAPIClient):
 
     def list_plots_analysis_reports(
         self,
-        plots_group_id: str,
         plots_analysis_id: str,
+        plots_group_id: str,
     ):
         """
         List all the reports belonging to a given plots analysis
 
         Args:
-            plots_group_id: id of the plots group on which we want to list the analyses
             plots_analysis_id: id of the plots analysis for which we want to list the reports
+            plots_group_id: id of the plots group on which we want to list the analyses
 
         Returns: see https://app.picterra.ch/public/apidocs/plots_analysis/v1/#tag/reports/operation/getReportsList
         """  # noqa[E501]
@@ -313,15 +313,15 @@ class TracerClient(BaseAPIClient):
 
     def list_plots_analyses_report_types(
         self,
+        plots_analysis_id: str,
         plots_group_id: str,
-        plots_analysis_id: str
     ):
         """
         List all the plots analyses report types the user can use (see create_plots_analysis_report)
 
         Args:
-            plots_group_id: id of the plots group
             plots_analysis_id: id of the plots analysis
+            plots_group_id: id of the plots group
 
         Returns:
             see https://app.picterra.ch/public/apidocs/plots_analysis/v1/#tag/reports/operation/getReportTypesForAnalysis
@@ -334,11 +334,12 @@ class TracerClient(BaseAPIClient):
 
     def create_plots_analysis_report_precheck(
         self,
-        plots_group_id: str,
         plots_analysis_id: str,
         report_name: str,
         plot_ids: List[str],
         report_type: str,
+        plots_group_id: str,
+        /,
         metadata: Optional[dict] = None
     ) -> dict:
         """
@@ -347,11 +348,11 @@ class TracerClient(BaseAPIClient):
         If the function fails, the report is not valid
 
         Args:
-            plots_group_id: id of the plots group
             plots_analysis_id: id of the plots analysis
             report_name: name to give to the report
             plot_ids: list of the plot ids to select for the report
             report_type: type of report to generate, as per list_plots_analyses_report_types
+            plots_group_id: id of the plots group
             metadata:  set of key-value pairs which may be included in the report
 
         Returns:
@@ -376,22 +377,23 @@ class TracerClient(BaseAPIClient):
 
     def create_plots_analysis_report(
         self,
-        plots_group_id: str,
         plots_analysis_id: str,
         report_name: str,
         plot_ids: List[str],
         report_type: str,
+        plots_group_id: str,
+        /,
         metadata: Optional[dict] = None
     ) -> str:
         """
         Creates a report
 
         Args:
-            plots_group_id: id of the plots group
             plots_analysis_id: id of the plots analysis
             report_name: name to give to the report
             plot_ids: list of the plot ids to select for the report
             report_type: type of report to generate, as per list_plots_analyses_report_types
+            plots_group_id: id of the plots group
             metadata:  set of key-value pairs which may be included in the report
 
         Returns:
@@ -415,13 +417,13 @@ class TracerClient(BaseAPIClient):
         report_id = op_result["results"]["plots_analysis_report_id"]
         return report_id
 
-    def get_plots_analysis(self, plots_group_id: str, plots_analysis_id: str):
+    def get_plots_analysis(self, plots_analysis_id: str, plots_group_id: str):
         """
         Get plots analysis information
 
         Args:
-            plots_group_id: id of the plots group
             plots_analysis_id: id of the plots analysis
+            plots_group_id: id of the plots group
 
         Raises:
             APIError: There was an error while getting the plots analysis information
@@ -433,14 +435,14 @@ class TracerClient(BaseAPIClient):
         _check_resp_is_ok(resp, "Failed to get plots analysis")
         return resp.json()
 
-    def get_plots_analysis_report(self, plots_group_id: str, plots_analysis_id: str, plots_analysis_report_id: str):
+    def get_plots_analysis_report(self, plots_analysis_report_id: str, plots_group_id: str, plots_analysis_id: str, ):
         """
         Get plots analysis report information
 
         Args:
+            plots_analysis_report_id: id of the plots analysis report
             plots_group_id: id of the plots group
             plots_analysis_id: id of the plots analysis
-            plots_analysis_report_id: id of the plots analysis report
 
         Raises:
             APIError: There was an error while getting the plots analysis report information

--- a/src/picterra/tracer_client.py
+++ b/src/picterra/tracer_client.py
@@ -311,7 +311,7 @@ class TracerClient(BaseAPIClient):
             f"plots_groups/{plots_group_id}/analysis/{plots_analysis_id}/reports/"
         )
 
-    def list_plots_analyses_report_types(
+    def list_plots_analysis_report_types(
         self,
         plots_analysis_id: str,
         plots_group_id: str,
@@ -339,7 +339,7 @@ class TracerClient(BaseAPIClient):
         plot_ids: List[str],
         report_type: str,
         plots_group_id: str,
-        /,
+        *,
         metadata: Optional[dict] = None
     ) -> dict:
         """
@@ -382,7 +382,7 @@ class TracerClient(BaseAPIClient):
         plot_ids: List[str],
         report_type: str,
         plots_group_id: str,
-        /,
+        *,
         metadata: Optional[dict] = None
     ) -> str:
         """
@@ -392,7 +392,7 @@ class TracerClient(BaseAPIClient):
             plots_analysis_id: id of the plots analysis
             report_name: name to give to the report
             plot_ids: list of the plot ids to select for the report
-            report_type: type of report to generate, as per list_plots_analyses_report_types
+            report_type: type of report to generate, as per list_plots_analysis_report_types
             plots_group_id: id of the plots group
             metadata:  set of key-value pairs which may be included in the report
 

--- a/tests/test_tracer_client.py
+++ b/tests/test_tracer_client.py
@@ -317,7 +317,7 @@ def test_list_plots_analysis_report_types(monkeypatch):
             {"report_type": "type_3", "name": "a_4"},
         ],
     )
-    reports = client.list_plots_analyses_report_types("my-analysis-id", "my-pg-id")
+    reports = client.list_plots_analysis_report_types("my-analysis-id", "my-pg-id")
     assert len(reports) == 4
     assert reports[0]["report_type"] == "type_1" and reports[-1]["name"] == "a_4"
 

--- a/tests/test_tracer_client.py
+++ b/tests/test_tracer_client.py
@@ -296,18 +296,18 @@ def test_download_plots_group(monkeypatch):
 @responses.activate
 def test_list_plots_analysis_reports(monkeypatch):
     client: TracerClient = _client(monkeypatch, platform="plots_analysis")
-    url = plots_analysis_api_url("plots_groups/FOO/analysis/BAR/reports/")
+    url = plots_analysis_api_url("plots_groups/my-pg-id/analysis/my-analysis-id/reports/")
     # Full list
     add_mock_paginated_list_response(url, num_results=3)
-    reports = client.list_plots_analysis_reports("FOO", "BAR")
+    reports = client.list_plots_analysis_reports("my-analysis-id", "my-pg-id")
     assert len(reports) == 3
     assert reports[0]["name"] == "a_1" and reports[-1]["name"] == "a_3"
 
 
 @responses.activate
-def test_list_plots_analyses_report_types(monkeypatch):
+def test_list_plots_analysis_report_types(monkeypatch):
     client: TracerClient = _client(monkeypatch, platform="plots_analysis")
-    url = plots_analysis_api_url("plots_groups/FOO/analysis/BAR/reports/types/")
+    url = plots_analysis_api_url("plots_groups/my-pg-id/analysis/my-analysis-id/reports/types/")
     responses.get(
         url,
         json=[
@@ -317,7 +317,7 @@ def test_list_plots_analyses_report_types(monkeypatch):
             {"report_type": "type_3", "name": "a_4"},
         ],
     )
-    reports = client.list_plots_analyses_report_types("FOO", "BAR")
+    reports = client.list_plots_analyses_report_types("my-analysis-id", "my-pg-id")
     assert len(reports) == 4
     assert reports[0]["report_type"] == "type_1" and reports[-1]["name"] == "a_4"
 
@@ -355,12 +355,12 @@ def test_create_plots_analysis_report_precheck(monkeypatch):
         with open(tmp.name, "w") as f:
             json.dump({"type": "FeatureCollection", "features": []}, f)
     assert client.create_plots_analysis_report_precheck(
-        "a-group-id",
         "an-analysis-id",
         "foobar",
         ["uno", "dos"],
         "a-report-type",
-        {"foo": "bar"}
+        "a-group-id",
+        metadata={"foo": "bar"}
     ) == {"status": "passed"}
 
 
@@ -397,12 +397,12 @@ def test_create_plots_analysis_report(monkeypatch):
         with open(tmp.name, "w") as f:
             json.dump({"type": "FeatureCollection", "features": []}, f)
     assert client.create_plots_analysis_report(
-        "a-group-id",
         "an-analysis-id",
         "foobar",
         ["uno", "dos"],
         "a-report-type",
-        {"foo": "bar"}
+        "a-group-id",
+        metadata={"foo": "bar"}
     ) == "a-report-id"
 
 
@@ -420,7 +420,7 @@ def test_get_plots_analysis(monkeypatch):
             "url": "https://app.picterra.ch/plots_analysis/plots_groups/136b812e-8d9c-418f-b317-8be5c7c6281d/analysis/cda443d7-5baf-483d-bb5e-fa1190180b0d/"  # noqa[E501]
         },
     )
-    plots_analysis = client.get_plots_analysis("a-plots-group", "an-analysis-id")
+    plots_analysis = client.get_plots_analysis("an-analysis-id", "a-plots-group")
     assert plots_analysis["id"] == "an-analysis-id"
     assert plots_analysis["name"] == "My Analysis"
 
@@ -458,6 +458,6 @@ def test_get_plots_analysis_report(monkeypatch):
         },
     )
     client: TracerClient = _client(monkeypatch, platform="plots_analysis")
-    report = client.get_plots_analysis_report("a-group-id", "a-analysis-id", "a-report-id")
+    report = client.get_plots_analysis_report("a-report-id", "a-group-id", "a-analysis-id")
     assert report["id"] == "a-report-id"
     assert report["artifacts"][0]["name"] == "EUDR Report"


### PR DESCRIPTION
We will likely simplify the URL structure so that getting a report doesn't
require passing the plots group and plots analysis ids, but only the report id.

By reversing argumenst to have the most specific id first, we will be able
to make this change in a backward-compatible manner, by just making the
other ids optional.

Also renames list_plots_analyses_report_types to list_plots_analysis_report_types for consistency.