### PR TITLE
[tracer] Add the ability to include archived objects in queries

### DIFF
--- a/src/picterra/tracer_client.py
+++ b/src/picterra/tracer_client.py
@@ -159,6 +159,7 @@ class TracerClient(BaseAPIClient):
         self,
         search: Optional[str] = None,
         page_number: Optional[int] = None,
+        include_archived: bool = False,
     ) -> ResultsPage:
         """
         List all the plots group the user can access, see `ResultsPage`
@@ -170,6 +171,7 @@ class TracerClient(BaseAPIClient):
         Args:
             search: The term used to filter by name
             page_number: Optional page (from 1) of the list we want to retrieve
+            include_archived: If true, includes archived plot groups in the results
 
         Returns:
             See https://app.picterra.ch/public/apidocs/plots_analysis/v1/#tag/plots-groups/operation/getPlotsGroupsList
@@ -179,6 +181,8 @@ class TracerClient(BaseAPIClient):
             data["search"] = search.strip()
         if page_number is not None:
             data["page_number"] = int(page_number)
+        if include_archived:
+            data["include_archived"] = include_archived
         return self._return_results_page("plots_groups", data)
 
     def analyze_plots_precheck(
@@ -263,6 +267,7 @@ class TracerClient(BaseAPIClient):
         plots_group_id: str,
         search: Optional[str] = None,
         page_number: Optional[int] = None,
+        include_archived: bool = False,
     ) -> ResultsPage:
         """
         List all the plots analyses the user can access, see `ResultsPage`
@@ -274,11 +279,14 @@ class TracerClient(BaseAPIClient):
             plots_group_id: id of the plots group on which we want to list the analyses
             search: The term used to filter by name
             page_number: Optional page (from 1) of the list we want to retrieve
+            include_archived: Defaults to false. If true, includes archived analyses in the results
 
         Returns:
             See https://app.picterra.ch/public/apidocs/plots_analysis/v1/#tag/analysis/operation/getPlotsAnalysesList
         """
         data: Dict[str, Any] = {}
+        if include_archived:
+            data["include_archived"] = str(include_archived).lower()
         if search is not None:
             data["search"] = search.strip()
         if page_number is not None:
@@ -289,19 +297,30 @@ class TracerClient(BaseAPIClient):
         self,
         plots_analysis_id: str,
         plots_group_id: str,
+        page_number: Optional[int] = None,
+        include_archived: bool = False,
     ) -> ResultsPage:
         """
-        List all the reports belonging to a given plots analysis
+        List all the reports belonging to a given plots analysis, see `ResultsPage`
+            for the pagination access pattern.
 
         Args:
             plots_analysis_id: id of the plots analysis for which we want to list the reports
             plots_group_id: id of the plots group on which we want to list the analyses
+            page_number: Optional page (from 1) of the list we want to retrieve
+            include_archived: Defaults to false. If true, includes archived analysis reports in the
+                              results
 
         Returns:
             See https://app.picterra.ch/public/apidocs/plots_analysis/v1/#tag/reports/operation/getReportsList
         """  # noqa[E501]
+        params: Dict[str, Any] = {}
+        if page_number is not None:
+            params["page_number"] = int(page_number)
+        if include_archived:
+            params["include_archived"] = include_archived
         return self._return_results_page(
-            f"plots_groups/{plots_group_id}/analysis/{plots_analysis_id}/reports/"
+            f"plots_groups/{plots_group_id}/analysis/{plots_analysis_id}/reports/", params
         )
 
     def list_plots_analysis_report_types(

--- a/tests/test_tracer_client.py
+++ b/tests/test_tracer_client.py
@@ -260,6 +260,11 @@ def test_list_plots_analyses(monkeypatch):
     add_mock_paginated_list_response(url, 2, "m_2", "spam")
     plots_analyses = client.list_plots_analyses("spam", search="m_2", page_number=2)
     assert plots_analyses[0]["name"] == "spam_1"
+    # Test the include_archived flag
+    add_mock_paginated_list_response(url, include_archived=True, name_prefix="boo")
+    plots_analyses = client.list_plots_analyses("spam", include_archived=True)
+    assert len(plots_analyses) == 2
+    assert plots_analyses[0]["name"] == "boo_1"
 
 
 @responses.activate

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from urllib.parse import urljoin
 
 import responses
@@ -52,7 +53,7 @@ def plots_analysis_api_url(path):
     return urljoin(TEST_API_URL, urljoin("public/api/plots_analysis/v1/", path))
 
 
-def add_mock_paginated_list_response(endpoint: str, page: int = 1, search_string: str = None, name_prefix: str = "a", num_results: int = 2):
+def add_mock_paginated_list_response(endpoint: str, page: int = 1, search_string: str = None, name_prefix: str = "a", num_results: int = 2, include_archived: Optional[bool] = None):
     curr, next = str(page), str(page + 1)
     data1 = {
         "count": num_results * num_results,
@@ -66,8 +67,11 @@ def add_mock_paginated_list_response(endpoint: str, page: int = 1, search_string
     qs_params = {"page_number": curr}
     if search_string:
         qs_params["search"] = search_string
+    if include_archived is not None:
+        qs_params["include_archived"] = str(include_archived).lower()
     _add_api_response(
-        endpoint + "?page_number=" + curr + (("&search=" + search_string) if search_string else ""),
+        endpoint + "?page_number=" + curr + (("&search=" + search_string) if search_string else "") + (
+            "&include_archived=" + str(include_archived).lower() if include_archived is not None else ""),
         match=responses.matchers.query_param_matcher(qs_params),
         json=data1,
     )


### PR DESCRIPTION
Allows querying archived plots groups, plots analyses and plot analysis reports

Also adds the ability to list more than one page of plots analysis reports

See also gitlab issue #7929 and MR !9332 for matching internal changes